### PR TITLE
Suppress a byte-compile warning

### DIFF
--- a/cmake-integration.el
+++ b/cmake-integration.el
@@ -33,6 +33,7 @@
 ;;; Code:
 (require 'project)
 (require 'f)
+(require 'json)
 
 
 ;; TODO: Only show the target names with


### PR DESCRIPTION
```
cmake-integration.el:162:60: Warning: the function ‘json-read-file’ is not
    known to be defined.
```