### PR TITLE
Allow presetName variable in cmake preset binaryDir

### DIFF
--- a/cmake-integration.el
+++ b/cmake-integration.el
@@ -185,7 +185,7 @@ project."
     (when project-root-folder
       (if cmake-integration-last-configure-preset
           ;; We have a configure preset -> let's use build folder pointed by it
-          (s-replace "${sourceDir}/" (cmake-integration-get-project-root-folder) (cmake-integration-get-binaryDir cmake-integration-last-configure-preset))
+          (s-replace-all `(("${sourceDir}/" . ,(cmake-integration-get-project-root-folder)) ("${presetName}". ,(alist-get 'name cmake-integration-last-configure-preset))) (cmake-integration-get-binaryDir cmake-integration-last-configure-preset))
 
         ;; We don't have a configure preset
         (if cmake-integration-build-dir


### PR DESCRIPTION
When using CMake Presets, CMake does allow the variable "presetName" to be used in the "binaryDir" property.
I have added a substitution for this variable when the build folder is retrieved.

Having this variable set in the preset, prevented cmake-integration from generating the compile_commands.json symbolic link which is needed for correct language server support.