### PR TITLE
feat: only store buffers with underlying files on save-and-compile

### DIFF
--- a/cmake-integration.el
+++ b/cmake-integration.el
@@ -669,7 +669,9 @@ If TARGET-NAME is not provided use the last target (saved in a
 (defun cmake-integration-save-and-compile-no-completion (target)
   "Save the buffer and compile TARGET."
   (interactive "sTarget: ")
-  (save-buffer 0)
+  (if (buffer-file-name)
+      (save-buffer 0)
+    )
 
   (check-if-build-folder-exists-and-throws-if-not)
 


### PR DESCRIPTION
My usual workflow is first configuring a project with a preset and afterwards compiling it.
The configuration step will open a *compilation* buffer which I always have to close before compiling, else I will be asked to save the compilation buffer somewhere.

I would therefore suggest to only save buffers which already have underlying files.