### PR TITLE
Fix use-package from failing to process the package-requires list

### DIFF
--- a/cmake-integration.el
+++ b/cmake-integration.el
@@ -2,7 +2,7 @@
 
 ;; Author: Darlan Cavalcante Moreira <darcamo@gmail.com>
 ;; Version: 0.1
-;; Package-Requires: ((emacs "28.1") f s json)
+;; Package-Requires: ((emacs "28.1") (f "0.20.0") (s "1.12.0") (json "1.5") (dash "2.19.1"))
 ;; Homepage: https://github.com/darcamo/cmake-integration
 ;; Keywords: c c++ cmake languages tools
 ;; URL: https://github.com/darcamo/cmake-integration/
@@ -35,6 +35,7 @@
 (require 'f)
 (require 's)
 (require 'json)
+(require 'dash)
 (require 'cl-extra)
 
 (require 'cmake-integration-variables)


### PR DESCRIPTION
Emacs version `30.1.50`
Message `version-to-list: Version must be a string`

When trying to import using `use-package` it cannot handle the package requirements as a list.

I changed the list to state which version is used and also included the missing package `dash.el`. 
With these changes `use-package` can now handle the requirements list.