### PR TITLE
Make cmake-integration work with TRAMP

### DIFF
--- a/cmake-integration-build.el
+++ b/cmake-integration-build.el
@@ -146,6 +146,9 @@ If a prefix argument is provided, then the value of
 temporarily considered as t.
 
 If two prefix arguments are provided, then all targets are included."
+  (when (or (null json-filename) (not (file-exists-p json-filename)))
+    (error "Could not find the CMake codemodel reply file. Please run either `cmake-integration-cmake-reconfigure' or `cmake-integration-cmake-configure-with-preset'"))
+
   (let* ((include-subprojects (or current-prefix-arg ci-include-subproject-targets-during-completion))
          (list-of-targets (if include-subprojects
                               (ci--get-targets-from-codemodel-json-file-2

--- a/cmake-integration-core.el
+++ b/cmake-integration-core.el
@@ -73,9 +73,9 @@ Otherwise return it unchanged."
   (unless (file-exists-p (ci--get-path-of-codemodel-query-file))
     ;; Create the folder if it does not exists yet
     (unless (file-exists-p (ci--get-query-folder))
-      (shell-command (concat "mkdir -p " (ci--get-query-folder))))
+      (make-directory (ci--get-query-folder) t))
     ;; Create the codemodel file
-    (shell-command (concat "touch " (ci--get-path-of-codemodel-query-file)))))
+    (make-empty-file (ci--get-path-of-codemodel-query-file))))
 
 
 (defun ci-get-build-folder ()

--- a/cmake-integration-launch.el
+++ b/cmake-integration-launch.el
@@ -69,35 +69,6 @@ If TARGET-NAME is not provided use the last target (saved in a
   (file-name-concat (ci-get-build-folder) executable-filename))
 
 
-(defun ci--get-run-command-project-root-cwd (executable-filename)
-  "Get the run command string for EXECUTABLE-FILENAME from the project root folder."
-  (format "%s %s"
-          (ci-get-target-executable-full-path executable-filename)
-          ci-run-arguments))
-
-
-(defun ci--get-run-command-build-folder-cwd (executable-filename)
-  "Get the run command string for EXECUTABLE-FILENAME from the build folder."
-  (format "%s %s" executable-filename ci-run-arguments))
-
-
-(defun ci--get-run-command-bin-folder-cwd (executable-filename)
-  "Get the run command string for EXECUTABLE-FILENAME from the binary folder.
-
-The binary folder is the folder containing the executable."
-  (format "./%s %s"
-          (file-name-nondirectory executable-filename)
-          ci-run-arguments))
-
-
-(defun ci--get-run-command-custom-cwd (executable-filename project-subfolder)
-  "Get run command string for EXECUTABLE-FILENAME from PROJECT-SUBFOLDER."
-  (cl-assert (stringp project-subfolder))
-  (format "%s %s"
-          (ci-get-target-executable-full-path executable-filename)
-          ci-run-arguments))
-
-
 (defun ci--compilation-buffer-name-function (name-of-mode)
   "Get the compilation buffer name for NAME-OF-MODE current target name."
   name-of-mode  ;; Avoid warning about unused argument
@@ -110,14 +81,11 @@ The binary folder is the folder containing the executable."
 Return a list (RUN-DIR COMMAND), where RUN-DIR is the directory from
 which the command must be executed, and COMMAND is the command line
 string to run."
-  (let ((run-dir (ci--get-working-directory executable-filename)))
+  (let* ((run-dir (ci--get-working-directory executable-filename))
+         (executable-path (file-relative-name (ci-get-target-executable-full-path executable-filename) run-dir)))
     (list
      run-dir
-     (pcase ci-run-working-directory
-       ('root (ci--get-run-command-project-root-cwd executable-filename))
-       ('build (ci--get-run-command-build-folder-cwd executable-filename))
-       ('bin (ci--get-run-command-bin-folder-cwd executable-filename))
-       (_ (ci--get-run-command-custom-cwd executable-filename ci-run-working-directory))))))
+     (format "./%s %s" executable-path ci-run-arguments))))
 
 
 ;;;###autoload (autoload 'cmake-integration-run-last-target "cmake-integration")

--- a/tests/cmake-integration-tests.el
+++ b/tests/cmake-integration-tests.el
@@ -337,11 +337,12 @@ test code from inside a 'test project'."
      (let ((cmake-integration-run-arguments "arg1 arg2 arg3")
            (cmake-integration-run-working-directory 'root))
        (let* ((expected-run-dir (cmake-integration--get-project-root-folder))
-              (expected-cmd (format "%s %s"
-                                    (cmake-integration-get-target-executable-full-path "bin/myexec")
+              (expected-cmd (format "./%s %s"
+                                    (file-relative-name (cmake-integration-get-target-executable-full-path "bin/myexec") expected-run-dir)
                                     cmake-integration-run-arguments)))
-         (should (equal (cmake-integration--get-run-command "bin/myexec")
-                        (list expected-run-dir expected-cmd))))))))
+         (pcase-let* ((`(,dir ,command) (cmake-integration--get-run-command "bin/myexec")))
+           (should (filepath-equal-p dir expected-run-dir))
+           (should (equal command expected-cmd))))))))
 
 (ert-deftest test-cmake-integration--get-run-command--build-folder ()
   (test-fixture-setup
@@ -350,9 +351,11 @@ test code from inside a 'test project'."
      (let ((cmake-integration-run-arguments "arg1 arg2 arg3")
            (cmake-integration-run-working-directory 'build))
        (let* ((expected-run-dir (cmake-integration-get-build-folder))
-              (expected-cmd (format "%s %s" "bin/myexec" cmake-integration-run-arguments)))
-         (should (equal (cmake-integration--get-run-command "bin/myexec")
-                        (list expected-run-dir expected-cmd))))))))
+              (expected-cmd (format "./%s %s" "bin/myexec" cmake-integration-run-arguments)))
+
+         (pcase-let* ((`(,dir ,command) (cmake-integration--get-run-command "bin/myexec")))
+           (should (filepath-equal-p dir expected-run-dir))
+           (should (equal command expected-cmd))))))))
 
 (ert-deftest test-cmake-integration--get-run-command--bin-folder ()
   (test-fixture-setup
@@ -362,8 +365,10 @@ test code from inside a 'test project'."
            (cmake-integration-run-working-directory 'bin))
        (let* ((expected-run-dir (file-name-concat (cmake-integration-get-build-folder) "bin/"))
               (expected-cmd (format "./%s %s" "myexec" cmake-integration-run-arguments)))
-         (should (equal (cmake-integration--get-run-command "bin/myexec")
-                        (list expected-run-dir expected-cmd))))))))
+
+         (pcase-let* ((`(,dir ,command) (cmake-integration--get-run-command "bin/myexec")))
+           (should (filepath-equal-p dir expected-run-dir))
+           (should (equal command expected-cmd))))))))
 
 (ert-deftest test-cmake-integration--get-run-command--custom-folder ()
   (test-fixture-setup
@@ -372,13 +377,13 @@ test code from inside a 'test project'."
      (let ((cmake-integration-run-arguments "arg1 arg2 arg3")
            (cmake-integration-run-working-directory "subfolder"))
        (let* ((expected-run-dir (file-name-concat (cmake-integration--get-project-root-folder) "subfolder"))
-              (expected-cmd (format "%s %s"
-                                    (cmake-integration-get-target-executable-full-path "bin/myexec")
+              (expected-cmd (format "./%s %s"
+                                    (file-relative-name (cmake-integration-get-target-executable-full-path "bin/myexec") expected-run-dir)
                                     cmake-integration-run-arguments)))
-         (should (equal (cmake-integration--get-run-command "bin/myexec")
-                        (list expected-run-dir expected-cmd))))))))
 
-
+         (pcase-let* ((`(,dir ,command) (cmake-integration--get-run-command "bin/myexec")))
+           (should (filepath-equal-p dir expected-run-dir))
+           (should (equal command expected-cmd))))))))
 
 (ert-deftest test-cmake-integration--get-debug-command--root-folder ()
   (test-fixture-setup

--- a/tests/test-project/conanfile.txt
+++ b/tests/test-project/conanfile.txt
@@ -1,9 +1,11 @@
 [requires]
-catch2/2.13.8
+catch2/3.10.0
 
 [generators]
 CMakeDeps
 CMakeToolchain
 
 [options]
-catch2:with_main=True
+
+[layout]
+cmake_layout

--- a/tests/test-project/tests/CMakeLists.txt
+++ b/tests/test-project/tests/CMakeLists.txt
@@ -1,9 +1,9 @@
 
-find_package(catch2)
+find_package(Catch2 REQUIRED)
 
 add_executable(tests test_functions.cpp)
 # target_link_libraries(tests catch2::catch2)
-target_link_libraries(tests PUBLIC catch2::Catch2WithMain functions)
+target_link_libraries(tests PUBLIC Catch2::Catch2WithMain functions)
 
 include(CTest)
 include(Catch)


### PR DESCRIPTION
Previously, the CMake and Conan commands used `cd` to change directories before execution. This approach has been replaced with binding the `default-directory` variable. The behavior remains the same, but this method improves compatibility with TRAMP, as `default-directory` is TRAMP-aware, whereas a direct `cd` is not.