### PR TITLE
Fix TRAMP when using a relative path in binaryDir

### DIFF
--- a/cmake-integration-configure.el
+++ b/cmake-integration-configure.el
@@ -42,26 +42,12 @@ If not available, get the binaryDir or a parent preset."
       (match-string 1 path)))
 
 
-(defun ci--add-remote-prefix-to-path (path)
-  "Add the TRAMP remote prefix from `default-directory' to PATH.
-
-Returns PATH unchanged if `default-directory' is not remote or if PATH
-is already remote."
-  (if (and (file-remote-p default-directory)
-           (not (file-remote-p path)))
-      (let ((remote-prefix (ci--extract-remote-prefix default-directory)))
-        (concat remote-prefix path))
-    path))
-
-
 (defun ci--get-binaryDir-with-replacements (preset)
   "Get the `binaryDir' field of a preset PRESET, and also perform the replacements."
   (if-let* ((binaryDir (ci--get-binaryDir preset))
             (project-root (ci--get-project-root-folder))
-            (preset-name (ci--get-preset-name preset))
-            (binaryDir-with-replacements (ci--perform-binaryDir-replacements binaryDir project-root preset-name)))
-      ;; Make sure to add the TRAMP prefix if needed
-      (ci--add-remote-prefix-to-path binaryDir-with-replacements)))
+            (preset-name (ci--get-preset-name preset)))
+      (ci--perform-binaryDir-replacements binaryDir project-root preset-name)))
 
 
 (defun ci--get-configure-preset-by-name (preset-name)

--- a/cmake-integration-core.el
+++ b/cmake-integration-core.el
@@ -97,8 +97,8 @@ resolved against the project root."
       (error "Not in a project"))
 
     (if preset
-        ;; Use the build folder from the configure preset
-        (expand-file-name (ci--get-binaryDir-with-replacements preset) project-root-folder)
+        (let ((binaryDir-with-replacements (ci--get-binaryDir-with-replacements preset)))
+          (expand-file-name binaryDir-with-replacements project-root-folder))
 
       ;; Use manually set build directory or throw an error
       (if build-dir

--- a/tests/cmake-integration-tests.el
+++ b/tests/cmake-integration-tests.el
@@ -279,8 +279,12 @@ test code from inside a 'test project'."
 
 (ert-deftest test-cmake-integration--get-query-folder ()
   (test-fixture-setup
-   "./test-project"
-   (lambda () (should (filepath-equal-p (cmake-integration--get-query-folder) "./build/.cmake/api/v1/query/client-emacs")))))
+   "./test-project/subfolder"
+   (lambda ()
+     (let* ((build-folder (cmake-integration-get-build-folder))
+            (query-relative-path ".cmake/api/v1/query/client-emacs")
+            (expected-query-folder (expand-file-name query-relative-path build-folder)))
+       (should (filepath-equal-p (cmake-integration--get-query-folder) expected-query-folder))))))
 
 
 (ert-deftest test-cmake-integration--get-reply-folder ()


### PR DESCRIPTION
The `ci--get-binaryDir-with-replacements` function will now solely handle replacements and no longer append the TRAMP component to its return value. Instead, the returned value will be combined with the project root in `ci-get-build-folder`. Since the project root is obtained from Emacs' `project` package, it will always include the correct TRAMP portion for remote connections.