### PR TITLE
Replace env in binaryDir preset.

### DIFF
--- a/cmake-integration-configure.el
+++ b/cmake-integration-configure.el
@@ -52,6 +52,16 @@
     (setq ci-generator chosen-generator)))
 
 
+(defun ci--cmake-expand-env-vars (s)
+  "Expand $env{VAR} in string S."
+  (let ((expanded
+         (replace-regexp-in-string
+          "\\$env{\\([^}]+\\)}"
+          (lambda (match)
+            (or (getenv (match-string 1 match)) ""))
+          s)))
+      expanded))
+
 (defun ci--perform-binaryDir-replacements (binaryDir project-root-folder preset-name)
   "Replace `${sourceDir}' and `${presetName}' in a BINARYDIR string.
 
@@ -61,8 +71,7 @@ NOTE: `project-root-folder' must end with a slash."
   (let* ((source-dir-replacement (cons "${sourceDir}/" project-root-folder))
          (preset-name-replacement (cons "${presetName}" preset-name))
          (replacements (list source-dir-replacement preset-name-replacement)))
-    (s-replace-all replacements binaryDir)))
-
+    (ci--cmake-expand-env-vars (s-replace-all replacements binaryDir))))
 
 (defun ci--get-binaryDir (preset)
   "Get the `binaryDir' field of a preset PRESET.

--- a/cmake-integration-launch.el
+++ b/cmake-integration-launch.el
@@ -124,7 +124,7 @@ which the command must be executed, and COMMAND is the command line
 string to run."
   (let* ((run-dir (ci--get-working-directory executable-filename))
          (executable-relative-path (file-relative-name (ci-get-target-executable-full-path executable-filename) run-dir))
-         (run-command (format "./%s %s" executable-relative-path ci-run-arguments)))
+         (run-command (format "./%s %s" executable-relative-path (or ci-run-arguments ""))))
     (list run-dir run-command)))
 
 

--- a/cmake-integration-transient.el
+++ b/cmake-integration-transient.el
@@ -198,9 +198,10 @@ will be obtained from PRESET and this returns the string
   :transient 'transient--do-call
   :description #'ci--describe-configure-preset-command-line
   (interactive)
-  (if ci-configure-preset
-      (setq ci-configure-preset nil)
-    (ci-select-configure-preset)))
+;;  (if ci-configure-preset
+;;      (setq ci-configure-preset nil)
+  (ci-select-configure-preset))
+;;)
 
 
 (transient-define-suffix ci--set-build-preset-suffix ()
@@ -296,9 +297,10 @@ will be obtained from PRESET and this returns the string
   :transient 'transient--do-call
   :description #'ci--describe-ctest-label-exclude-regexp
   (interactive)
-  (if ci--ctest-label-exclude-regexp
-      (setq ci--ctest-label-exclude-regexp nil)
-    (ci-select-ctest-labels-to-exclude)))
+;  (if ci--ctest-label-exclude-regexp
+;      (setq ci--ctest-label-exclude-regexp nil)
+  (ci-select-ctest-labels-to-exclude))
+;)
 
 
 (transient-define-prefix ci--conan-list-prefix ()


### PR DESCRIPTION
I use it with 
```json
	    "binaryDir": "$env{BUILD_POOL_PREFIX}/${presetName}"
```
and something to set env before build
```common_lisp
  (defun dlyr/dir-name-function (project-root)
    "Return the directory name to run CMake in based on PROJECT-ROOT."
    (replace-regexp-in-string "[-/= #]" "_"  (concat (expand-file-name project-root)
						     (if (fboundp 'magit-get-current-branch) (magit-get-current-branch) ""))))


  (defun dlyr/cmake-setup-env-vars (&optional _)
    "Automatically set env BUILD_POOL_PREFIX and GIT_BRANCH env vars before running cmake."
    (if-let* ((project (project-current))
              (project-root (project-root project))
              (build-dir (dlyr/dir-name-function project-root))
              (prefix (or dlyr/cmake-build-pool-dir "build-pool")))
        (setenv "BUILD_POOL_PREFIX" (concat prefix build-dir))
    (setenv "BUILD_POOL_PREFIX" "local-build-pool")))

(advice-add 'cmake-integration-cmake-reconfigure :before #'dlyr/cmake-setup-env-vars)
```