### PR TITLE
Use the correct relative-path separator under Windows

### DIFF
--- a/cmake-integration-launch.el
+++ b/cmake-integration-launch.el
@@ -100,7 +100,8 @@ which the command must be executed, and COMMAND is the command line
 string to run."
   (let* ((run-dir (ci--get-working-directory executable-filename))
          (executable-relative-path (file-relative-name (ci-get-target-executable-full-path executable-filename) run-dir))
-         (run-command (format "./%s %s" executable-relative-path ci-run-arguments)))
+         (path-separator (if (eq system-type 'windows-nt) "\\" "/"))
+         (run-command (format ".%s%s %s" path-separator executable-relative-path ci-run-arguments)))
     (list run-dir run-command)))
 
 


### PR DESCRIPTION
For reasons I cannot comprehend, having `ci-run-arguments` set to a non-empty string and executing `M-x ci-run-last-target` (on Windows 10) produces the following error message:

```
./dwarfpaper.exe -D -m forest
'.' is not recognized as an internal or external command,
operable program or batch file.
```

Replacing the forward-slash `/` with a backslash `\` solved the issue, at least for my case.

What confuses me the most, is that this issue never occurred until I decided to set `ci-run-arguments`. Running executables with the forward-slash `/` separator (`./dwarfpaper.exe`) but without the args, worked fine all this time I've been using the package.

Let me know if you have any suggestions for this PR.