### PR TITLE
Add cmake-integration-project-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,14 +31,7 @@ The package is available on GitHub. You can install it using your preferred Emac
     ```emacs-lisp
     (use-package cmake-integration
       :ensure (cmake-integration :type git :host github 
-                                 :repo "darcamo/cmake-integration")
-      :commands (cmake-integration-conan-manage-remotes
-                 cmake-integration-conan-list-packages-in-local-cache
-                 cmake-integration-search-in-conan-center
-                 cmake-integration-transient)
-      :custom
-      (cmake-integration-generator "Ninja")
-      (cmake-integration-use-separated-compilation-buffer-for-each-target t))
+                                 :repo "darcamo/cmake-integration"))
     ```
 
 - **Use-package with `vc` backend:**
@@ -50,8 +43,8 @@ The package is available on GitHub. You can install it using your preferred Emac
 
 ## Usage
 
-The package provides a transient menu (`cmake-integration-transient`) for quick access to its functions. For efficient
-workflow, consider binding frequently used commands to custom keybindings.
+The package provides a transient menu (`cmake-integration-transient`) for quick access to its functions. For an
+efficient workflow, consider binding frequently used commands to custom keybindings.
 
 ![Main transient menu](images/transient-menu.png)
 
@@ -113,54 +106,15 @@ The following Emacs Lisp code demonstrates how to bind most useful commands to c
               ))
 ```
 
-To make these keybindings available globally in CMake projects, regardless of the buffer's major mode, but only in
-projects using CMake, you can use the following configuration:
-
-```emacs-lisp
-(defun is-cmake-project? ()
-  "Determine if the current directory is a CMake project."
-  (interactive)
-  (if-let* ((project (project-current))
-            (project-root (project-root project))
-            (cmakelist-path (expand-file-name "CMakeLists.txt" project-root)))
-      (file-exists-p cmakelist-path)))
+You can also add these keybindings to the global map, but that would make them available even when not working in a
+CMake project, which is not very useful. A more convenient approach is to use `cmake-integration-project-mode`. It's a
+minor mode without any functionality, besides having a dedicated keymap and hook. You can replace `c++-mode-map` in the
+above code snippet with `cmake-integration-project-mode-map`, and then enable `cmake-integration-project-mode` in any
+buffer you want the keybinds to be active.
 
 
-(defun cmake-integration-keybindings-mode-turn-on-in-cmake-projects ()
-  "Turn on `cmake-integration-keybindings-mode' in CMake projects."
-  (when (is-cmake-project?)
-    (cmake-integration-keybindings-mode 1)))
-
-      
-(define-minor-mode cmake-integration-keybindings-mode
-  "A minor-mode for adding keybindings to compile C++ code using cmake-integration package."
-  nil
-  "cmake"
-  '(
-    ([f5] . cmake-integration-transient)                         ;; Open main transient menu
-    ([M-f9] . cmake-integration-select-current-target)           ;; Ask for the target name and compile it
-    ([f9] . cmake-integration-save-and-compile-last-target)      ;; Recompile the last target
-    ([C-f9] . cmake-integration-run-ctest)                       ;; Run CTest
-    ([f10] . cmake-integration-run-last-target)                  ;; Run the target (using any previously set command line parameters)
-    ([S-f10] . kill-compilation)
-    ([C-f10] . cmake-integration-debug-last-target)              ;; Debug the target (using any previously set command line parameters)
-    ([M-f10] . cmake-integration-run-last-target-with-arguments) ;; Ask for command line parameters to run the target
-    ([M-f8] . cmake-integration-select-configure-preset)         ;; Ask for a preset name and call CMake to configure the project
-    ([f8] . cmake-integration-cmake-reconfigure)                 ;; Call CMake to configure the project using the last chosen preset
-    )
-  )
-
-(define-globalized-minor-mode global-cmake-integration-keybindings-mode
-  cmake-integration-keybindings-mode cmake-integration-keybindings-mode-turn-on-in-cmake-projects)
-
-;; Turn on the global minor mode that automatically enables the buffer local
-;; minor mode in any buffer inside a CMake project
-(global-cmake-integration-keybindings-mode)
-```
-
-This defines a local minor mode with the keybindings, a function that determine if the current directory is in a CMake
-based project, and a global mode that uses that to decide if the local minor mode should be activated when you switch to
-a buffer.
+Tip: One way to automatically enable `cmake-integration-project-mode` in any buffer which is part of a CMake project, is
+to enable `global-cmake-integration-project-mode`.
 
 ## Extra Configuration
 

--- a/cmake-integration-core.el
+++ b/cmake-integration-core.el
@@ -34,14 +34,7 @@
 (require 'cmake-integration-variables)
 
 
-;;;###autoload (autoload 'cmake-integration-is-cmake-project-p "cmake-integration")
-(defun ci-is-cmake-project-p ()
-  "Check if the current project is a CMake project."
-  (interactive)
-  (if-let* ((project (project-current))
-            (project-root (project-root project))
-            (cmakelist-path (expand-file-name "CMakeLists.txt" project-root)))
-      (file-exists-p cmakelist-path)))
+
 
 
 ;; BUG: This function seems to work correctly, but when used as the

--- a/cmake-integration-persistence.el
+++ b/cmake-integration-persistence.el
@@ -32,6 +32,7 @@
 (require 'project nil t)
 (require 'cmake-integration-variables nil t)
 (require 'cmake-integration-core nil t)
+(require 'cmake-integration-project-mode nil t)
 
 
 (defvar ci-last-save-or-restore-state nil

--- a/cmake-integration-project-mode.el
+++ b/cmake-integration-project-mode.el
@@ -1,0 +1,96 @@
+;;; cmake-integration-project-mode.el --- Automatically detect when in a CMake project  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2025 Darlan Cavalcante Moreira
+
+;; Author: Darlan Cavalcante Moreira <darcamo@gmail.com>
+
+;; SPDX-License-Identifier: GPL-3.0-or-later
+
+;; This file is not part of GNU Emacs
+
+;; This file is part of cmake-integration.
+
+;; cmake-integration is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; cmake-integration is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with cmake-integration. If not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; This module provides a minor mode that has no functionality beyond having a
+;; key-map for CMake-related commands and running hooks. This gives the user
+;; more flexibility when setting keybindings for CMake projects. It also
+;; provides functionality to automatically detect if the current project is a
+;; CMake project by looking for CMakeLists.txt files in the project root and
+;; activate the minor-mode accordingly.
+
+;;; Code:
+
+(require 'cmake-integration-variables)
+
+
+(defcustom ci-project-ignored-major-modes nil
+  "List of major modes for which not to enable project mode.
+
+When `global-cmake-integration-project-mode' is enabled and the current
+project is detected as a CMake project, the
+`cmake-integration-project-mode' minor mode is enabled. However, if the
+current major mode is in this list, the minor mode will not be enabled."
+  :type '(repeat symbol)
+  :group 'cmake-integration-project)
+
+
+;;;###autoload (autoload 'cmake-integration-is-cmake-project-p "cmake-integration-project-mode" nil t)
+(defun ci-is-cmake-project-p ()
+  "Check if the current project is a CMake project."
+  (interactive)
+  (if-let* ((project (project-current))
+            (project-root (project-root project))
+            (cmakelist-path (expand-file-name "CMakeLists.txt" project-root)))
+    (file-exists-p cmakelist-path)))
+
+
+(defvar ci-project-mode-map (make-sparse-keymap)
+  "Keymap for `cmake-integration-project-mode'.")
+
+
+;;;###autoload (autoload 'cmake-integration-project-mode "cmake-integration-project-mode" nil t)
+(define-minor-mode ci-project-mode
+  "A minor-mode for CMake projects.
+
+This minor-mode does not add any functionality, but it can be used to
+add keybindings to compile C++ code using cmake-integration package and
+also running anything in its hook."
+  :keymap
+  ci-project-mode-map
+  (require 'cmake-integration))
+
+
+(defun ci--turn-on-project-mode-func ()
+  "Turn on `cmake-integration-project-mode' in CMake projects."
+  (when (and (ci-is-cmake-project-p)
+             (not (member major-mode ci-project-ignored-major-modes)))
+    (ci-project-mode 1)))
+
+
+(define-globalized-minor-mode global-cmake-integration-project-mode
+  ci-project-mode
+  ci--turn-on-project-mode-func
+  :group 'cmake-integration-project)
+
+
+(provide 'cmake-integration-project-mode)
+
+;;; cmake-integration-project-mode.el ends here
+
+;; Local Variables:
+;; read-symbol-shorthands: (("ci-" . "cmake-integration-"))
+;; End:

--- a/cmake-integration-transient.el
+++ b/cmake-integration-transient.el
@@ -452,6 +452,7 @@ will be obtained from PRESET and this returns the string
   )
 
 
+;;;###autoload (autoload 'cmake-integration-transient "cmake-integration" nil t)
 (transient-define-prefix ci-transient ()
   "Main transient menu, from where all other transient menus can be reached."
   [

--- a/cmake-integration-variables.el
+++ b/cmake-integration-variables.el
@@ -45,6 +45,8 @@
 
 (defgroup cmake-integration-persistence nil "Persist state of cmake-integration for the project." :group 'cmake-integration :prefix "cmake-integration-")
 
+(defgroup cmake-integration-project nil "Minor mode for CMake project." :group 'cmake-integration :prefix "cmake-integration-")
+
 
 (defcustom ci-build-dir "build"
   "The build folder to use when presets are not used.

--- a/cmake-integration.el
+++ b/cmake-integration.el
@@ -51,7 +51,7 @@
 (require 'cmake-integration-extra)
 (require 'cmake-integration-transient)
 (require 'cmake-integration-persistence)
-
+(require 'cmake-integration-project-mode)
 
 (provide 'cmake-integration)
 


### PR DESCRIPTION
Add the `cmake-integration-project-mode` minor mode, and a global minor mode to automatically turn-on `cmake-integration-project-mode` in CMake projects.

This minor mode has no functionality, besides defining a keymap and having a hook. This provides more flexibility for the user when setting key bindings.