### PR TITLE
Improve completions

### DIFF
--- a/cmake-integration-build.el
+++ b/cmake-integration-build.el
@@ -181,19 +181,26 @@ depends on the target type."
      (t type))))
 
 
-(defun ci--target-annotation-function (target-name)
-  "Annotation function that takes a TARGET-NAME and return an annotation for it.
+(defun ci--target-annotation-suffix (target-name)
+  "Get the suffix to annotate TARGET-NAME."
+  (pcase (car (split-string target-name ci--multi-config-separator))
+    ("clean"  (propertize "Clean all compiled targets" 'face 'ci-phony-target-face))
+    ("all"  (propertize "Compile all targets" 'face 'ci-phony-target-face))
+    ("install"  (propertize "Install targets" 'face 'ci-phony-target-face))
+    (_  (ci--get-propertized-target-type-from-name target-name minibuffer-completion-table))))
 
-This is used in `cmake-integration--get-target-using-completions'
-when completing a target name to generate an annotation for that
-target, which is shown during the completions if you are using
-the marginalia package, or in Emacs standard completion buffer."
-  (let ((spaces (ci--get-annotation-initial-spaces target-name)))
-    (pcase (car (split-string target-name ci--multi-config-separator))
-      ("clean" (concat spaces (propertize "Clean all compiled targets" 'face 'ci-phony-target-face)))
-      ("all" (concat spaces (propertize "Compile all targets" 'face 'ci-phony-target-face)))
-      ("install" (concat spaces (propertize "Install targets" 'face 'ci-phony-target-face)))
-      (_ (concat spaces (ci--get-propertized-target-type-from-name target-name minibuffer-completion-table))))))
+
+(defun ci--target-affixation-function (targets)
+  "Affixation to be used during completion of TARGETS.
+
+This is used in `cmake-integration--get-target-using-completions' when
+completing target names to generate annotations for each target."
+  (mapcar
+   (lambda (target-name)
+     (let ((spaces (ci--get-annotation-initial-spaces target-name))
+           (suffix (ci--target-annotation-suffix target-name)))
+       (list target-name "" (concat spaces suffix))))
+   targets))
 
 
 (defun ci--target-completion-transformed (completion)
@@ -247,8 +254,8 @@ The grouping is done by the folder of the target."
   "Ask the user to choose one of the targets in LIST-OF-TARGETS using completions."
   (setq ci--list-of-targets list-of-targets)
   (let ((completion-extra-properties
-         `(:annotation-function
-           ci--target-annotation-function
+         `(:category cmake-target
+           :affixation-function ci--target-affixation-function
            :group-function ,ci-target-group-function)))
     (completing-read "Target: " list-of-targets nil t)))
 

--- a/cmake-integration-build.el
+++ b/cmake-integration-build.el
@@ -199,7 +199,7 @@ the marginalia package, or in Emacs standard completion buffer."
 (defun ci--target-completion-transformed (completion)
   "Transform function used during completion for COMPLETION."
   (if (equal completion ci-current-target)
-      (propertize completion 'face 'bold)
+      (propertize completion 'face 'success)
     completion)
   )
 

--- a/cmake-integration-conan.el
+++ b/cmake-integration-conan.el
@@ -229,6 +229,7 @@ performs SSL verification of not. Then it calls the `conan remote update
   "Select one of the available conan profiles and return the chosen one."
   (interactive)
   (let* ((all-profiles (ci--get-conan-available-profiles))
+         (completion-extra-properties `(:category conan-profile))
          (choice (completing-read "Conan profile: " all-profiles nil t)))
     (setq ci-conan-profile choice)))
 

--- a/cmake-integration-configure.el
+++ b/cmake-integration-configure.el
@@ -47,6 +47,7 @@
   "Select a CMake generator from the available ones in the system."
   (interactive)
   (let* ((all-generators (ci--get-available-generators))
+         (completion-extra-properties `(:category cmake-generator))
          (chosen-generator
           (completing-read "Select CMake generator: " all-generators nil t)))
     (setq ci-generator chosen-generator)))
@@ -151,6 +152,7 @@ The variable and its value are used when configuring the project with CMake."
   ;; Ask the user for a cache variable name and remove from the list. Use
   ;; completing-read.
   (let* ((var-names (mapcar 'car ci-cache-variables))
+         (completion-extra-properties `(:category cmake-cache-variable))
          (var-to-remove
           (completing-read "CMake Cache Variable to remove: " var-names nil t)))
     (setq ci-cache-variables

--- a/cmake-integration-core-presets.el
+++ b/cmake-integration-core-presets.el
@@ -180,8 +180,8 @@ marginalia package, or in Emacs standard completion buffer."
          (display-name (alist-get 'displayName (alist-get preset minibuffer-completion-table nil nil 'equal)))
          (preset-annotation (concat initial-spaces display-name)))
     (if (equal preset "No Preset")
-        no-preset-annotation
-      preset-annotation)))
+        (propertize no-preset-annotation 'face 'completions-annotations)
+      (propertize preset-annotation 'face 'completions-annotations))))
 
 
 (defun ci-select-preset (all-presets prompt)

--- a/cmake-integration-core-presets.el
+++ b/cmake-integration-core-presets.el
@@ -191,7 +191,8 @@ ALL-PRESETS is the list of all available presets. PROMPT is the prompt
 string for the `completing-read' function. Returns the selected preset
 or nil if \\='No Preset\\=' is selected."
   (let* ((collection (ci--prepare-for-completing-read all-presets))
-         (completion-extra-properties '(:annotation-function ci--annotation-from-displayName-function))
+         (completion-extra-properties '(:category cmake-preset
+                                        :annotation-function ci--annotation-from-displayName-function))
          (choice (completing-read prompt collection nil t)))
     (if (equal choice "No Preset")
         nil

--- a/cmake-integration-ctest.el
+++ b/cmake-integration-ctest.el
@@ -139,6 +139,7 @@ This function is added to `cmake-integration-after-set-configure-preset-hook'."
 (defun ci--select-ctest-labels ()
   "Select and returns one or more ctest labels."
   (let* ((labels (ci--get-all-ctest-labels))
+         (completion-extra-properties `(:category ctest-label))
          (selected-labels (completing-read-multiple
                            "Select labels to include (separated by comma): "
                            labels nil t)))


### PR DESCRIPTION
- Change the face of the current target from `'bold` to `'success`.
- Propertize annotations when choosing Conan presets
- Replace `:annotation-function` with `:affixation-function` and set category for the different completions (targets, presets, conan pfofiles, etc).

**Note**: If both an annotation-function and an affixation-function are provided, affixation-function takes precedence. Hence, if you want to replace the annotation with your own by adding an entry in `completion-category-overrides`, you will need to set the `affixation-function` and not the `annotation-function`.