### PR TITLE
feature: Support building multiple targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ This package provides seamless integration between Emacs and CMake-based C++ pro
 information. It simplifies common development tasks such as:
 
 - **Preset Management:** Easily select and apply CMake configure, build, test, and package presets.
-- **Target Compilation:** Compile specific targets within your project with a single keybinding.
+- **Target Compilation:** Select and compile one or more targets within your project with a single keybinding.
 - **Debugging:** Easily start debugging your executable targets with the classic gdb mi interface or with gdb through
   [dape](https://github.com/svaante/dape).
+- **Run and Debug Targets:** Independently choose which executable target is run and which one is debugged, from a
+  dedicated "Run and Debug" transient menu.
 - **Conan Integration:** Manage Conan packages and remotes directly from Emacs, call ``conan install`, etc..
 - **Language Servers:** Help language servers work correctly in the project.
 
@@ -61,28 +63,41 @@ Note: Try experimenting with with the transient menu to get a better idea about 
       File API.
     - **Important:** You must configure your project at least once before target-related features can work.
 
-2.  **Compile Target:**
-    - Use `cmake-integration-select-current-target` to select a target.
-    - Use `cmake-integration-save-and-compile-last-target` to compile the last selected target.
+2.  **Select Build Targets:**
+    - Use `cmake-integration-select-build-targets` to select one or more targets to compile. Use `TAB` to complete a
+      target name, then `,` (comma) to keep selecting more targets.
+      - **TIP:** The targets "all" and "clean" are always available.
+    - You can also add or remove single targets with `cmake-integration-add-build-target` and
+      `cmake-integration-remove-build-target`, or start over with `cmake-integration-clear-build-targets`.
+    - Use `cmake-integration-save-and-compile-last-target` to compile all selected targets. If no target was selected,
+      the default `all` target is built.
     - You can also use `cmake-integration-save-and-compile` to select a target and compile it in a single command.
 
-3.  **Run Target:**
-    - Use `cmake-integration-run-last-target` to execute the compiled executable.
+3.  **Select Run and Debug Targets:**
+    - In the transient menu, open the "Run and Debug" submenu (`o l`) and press `t` to select the executable used by
+      both the run (`r`) and debug (`d`) commands at once. This is also available as
+      `cmake-integration-select-run-and-debug-target`.
+    - To use different executables for running and debugging, call
+      `cmake-integration-select-run-target` or `cmake-integration-select-debug-target` directly. Each remembers its own
+      target until you change it.
+
+4.  **Run Target:**
+    - Use `cmake-integration-run-last-target` to execute the selected run target.
       - **TIP:** See the documentation of the `cmake-integration-program-launcher-function` variable if you want to
         customize how the program is executed.
     - If you need to pass any command line arguments to the executable, use
       `cmake-integration-run-last-target-with-arguments` to specify custom command-line arguments and then run the
       executable. Any subsequence call to `cmake-integration-run-last-target` will use these arguments as well.
 
-4.  **Debug Target:**
-    - Use `cmake-integration-debug-last-target` to debug the last compiled executable.
+5.  **Debug Target:**
+    - Use `cmake-integration-debug-last-target` to debug the selected debug target.
       - **TIP:** See the documentation of the `cmake-integration-debug-launcher-function` variable if you want to
         customize how the program is executed (such as using [dape](https://github.com/svaante/dape) instead of the
         native gdb in Emacs). In the particular case of dape, you might also be interested in calling
         `cmake-integration-setup-dape` in your Emacs configuration. This will add a configuration to the `dape-configs`
         variable that uses information from `cmake-integration`.
 
-5.  **Run Tests:**
+6.  **Run Tests:**
     - You can always choose a target that has the executable for your tests and run it as usual.
     - If you want to run the tests using CTest, use `cmake-integration-run-ctest`.
 
@@ -95,8 +110,8 @@ The following Emacs Lisp code demonstrates how to bind most useful commands to c
 (use-package cmake-integration
   :bind (:map c++-mode-map
               ([f5] . cmake-integration-transient)                         ;; Open main transient menu
-              ([M-f9] . cmake-integration-select-current-target)           ;; Ask for target
-              ([f9] . cmake-integration-save-and-compile-last-target)      ;; Recompile last target
+              ([M-f9] . cmake-integration-select-build-targets)            ;; Select targets
+              ([f9] . cmake-integration-save-and-compile-last-target)      ;; Recompile selected targets
               ([C-f9] . cmake-integration-run-ctest)                       ;; Run CTest
               ([f10] . cmake-integration-run-last-target)                  ;; Run last target (with saved args)
               ([S-f10] . kill-compilation)                                 ;; Stop compilation
@@ -363,14 +378,15 @@ directory within your Docker container, add the following line to your Emacs con
 
 `cmake-integration` offers support for saving/restoring the current state of its relevant variables. This is done by the
 `cmake-integration-save-state` and `cmake-integration-restore-state` functions, respectively. The saved state includes
-the last used presets, the current target, any run-time arguments for that target, and the cached list of available
-targets. The storage location is controlled by the `cmake-integration-persist-location` variable; it defaults to a
-project-specific directory under `user-emacs-directory`, but it can be pointed at a custom path or kept inside the
-project itself.
+the last used presets, the selected build targets, the selected run and debug targets, any run-time arguments for that
+target, and the cached list of available targets. The storage location is controlled by the
+`cmake-integration-persist-location` variable; it defaults to a project-specific directory under `user-emacs-directory`,
+but it can be pointed at a custom path or kept inside the project itself.
 
 If you prefer to save and restore state automatically, enable the global minor mode
-`cmake-integration-automatic-persistence-mode`. The mode installs advices so that selecting presets, targets, running
-executables, invoking CTest, and similar actions all keep the persisted data in sync automatically.
+`cmake-integration-automatic-persistence-mode`. The mode installs advices so that selecting presets, selecting build,
+run or debug targets, running executables, invoking CTest, and similar actions all keep the persisted data in sync
+automatically.
 
 Manual commands remain available for custom workflows:
 

--- a/cmake-integration-build.el
+++ b/cmake-integration-build.el
@@ -135,6 +135,10 @@ complain in that case."
     (error "The build folder is missing. Please run either `cmake-integration-cmake-reconfigure' or
 `cmake-integration-cmake-configure-with-preset' to configure the project")))
 
+(defun ci--ensure-target-list (targets)
+  "Return TARGETS as a list of strings (accepts a single string)."
+
+  (if (stringp targets) (list targets) targets))
 
 (defun ci--save-and-compile-no-completion (target &optional extra-args)
   "Save the buffer and compile TARGET also passing EXTRA-ARGS.
@@ -188,7 +192,7 @@ depends on the target type."
     ("clean"  (propertize "Clean all compiled targets" 'face 'ci-phony-target-face))
     ("all"  (propertize "Compile all targets" 'face 'ci-phony-target-face))
     ("install"  (propertize "Install targets" 'face 'ci-phony-target-face))
-    (_  (ci--get-propertized-target-type-from-name target-name minibuffer-completion-table))))
+    (_  (ci--get-propertized-target-type-from-name target-name ci--list-of-targets))))
 
 
 (defun ci--target-affixation-function (targets)
@@ -206,7 +210,7 @@ completing target names to generate annotations for each target."
 
 (defun ci--target-completion-transformed (completion)
   "Transform function used during completion for COMPLETION."
-  (if (equal completion ci-current-target)
+  (if (member completion ci-current-build-targets)
       (propertize completion 'face 'success)
     completion)
   )
@@ -251,15 +255,24 @@ The grouping is done by the folder of the target."
   )
 
 
-(defun ci--get-target-using-completions (list-of-targets)
-  "Ask the user to choose one of the targets in LIST-OF-TARGETS using completions."
+(defun ci--get-targets-using-completions (list-of-targets &optional single)
+  "Ask the user to choose targets in LIST-OF-TARGETS using completions.
+
+Return the chosen target names as a list. With SINGLE non-nil,
+ask for exactly one target."
+
   (setq ci--list-of-targets list-of-targets)
   (let ((completion-extra-properties
-         `(:category cmake-target
-           :affixation-function ci--target-affixation-function
-           :group-function ,ci-target-group-function)))
-    (completing-read "Target: " list-of-targets nil t)))
+         (ci--target-completion-extra-properties)))
+    (if single
+        (list (completing-read "Add target: " list-of-targets nil t))
+      (completing-read-multiple "Targets: " list-of-targets nil t))))
 
+(defun ci--target-completion-extra-properties ()
+  "Extra completion properties used when completing target names."
+  (list :category 'cmake-target
+        :affixation-function 'ci--target-affixation-function
+        :group-function ci-target-group-function))
 
 (defun ci--get-all-targets (json-filename)
   "Get all targets for completion specified in JSON-FILENAME.
@@ -309,18 +322,20 @@ If two prefix arguments are provided, then all targets are included."
      (t list-of-targets))))
 
 
-;;;###autoload (autoload 'cmake-integration-select-current-target "cmake-integration")
-(defun ci-select-current-target ()
-  "Ask for a target to build and return the target name."
+;;;###autoload (autoload 'cmake-integration-select-build-targets "cmake-integration")
+(defun ci-select-build-targets ()
+  "Ask for the targets to build, save and return them as a list."
 
-  ;; If the build folder is missing we should stop with an error
   (interactive)
+  ;; If the build folder is missing we should stop with an error
   (ci--check-if-build-folder-exists-and-throws-if-not)
 
   (if-let* ((json-filename (ci--get-codemodel-reply-json-filename))
             (list-of-targets (ci--get-all-targets json-filename))
-            (target (ci--get-target-using-completions list-of-targets)))
-      (setq ci-current-target target)
+            (targets (ci--get-targets-using-completions list-of-targets)))
+      (progn
+        (setq ci-current-build-targets (delete-dups targets))
+        (ci--forget-stale-runnable-targets))
 
     ;; If `json-filename' is nil that means we could not find the
     ;; CMake reply with the file API, which means the query file is
@@ -328,7 +343,58 @@ If two prefix arguments are provided, then all targets are included."
     (display-warning 'cmake-integration "Could not find list of targets due to CMake file API file
 missing. Please run either `cmake-integration-cmake-reconfigure' or
 `cmake-integration-cmake-configure-with-preset'.")
-    (setq ci-current-target nil)))
+    (setq ci-current-build-targets nil)
+    (setq ci-current-run-target nil)
+    (setq ci-current-debug-target nil))
+  ci-current-build-targets)
+
+(make-obsolete 'ci-select-current-target 'ci-select-build-targets "2026-08")
+(defalias 'ci-select-current-target #'ci-select-build-targets)
+
+(defun ci--forget-stale-runnable-targets ()
+  "Reset remembered run/debug targets that are no longer build targets."
+  (unless (member ci-current-run-target ci-current-build-targets)
+    (setq ci-current-run-target nil))
+  (unless (member ci-current-debug-target ci-current-build-targets)
+    (setq ci-current-debug-target nil)))
+
+;;;###autoload (autoload 'cmake-integration-add-build-target "cmake-integration")
+(defun ci-add-build-target ()
+  "Select a single target and append it to the build targets."
+  (interactive)
+  (ci--check-if-build-folder-exists-and-throws-if-not)
+
+  (if-let* ((json-filename (ci--get-codemodel-reply-json-filename))
+            (list-of-targets (ci--get-all-targets json-filename))
+            (target (car (ci--get-targets-using-completions list-of-targets 'single))))
+      (progn
+        (unless (member target ci-current-build-targets)
+          (push target ci-current-build-targets))
+        (ci--forget-stale-runnable-targets)
+        target)
+    (display-warning 'cmake-integration "Could not find list of targets due to CMake file API file
+missing. Please run either `cmake-integration-cmake-reconfigure' or
+`cmake-integration-cmake-configure-with-preset'.")))
+
+;;;###autoload (autoload 'cmake-integration-remove-build-target "cmake-integration")
+(defun ci-remove-build-target ()
+  "Select one of the already selected build targets and remove it from the list."
+  (interactive)
+  (if (not ci-current-build-targets)
+      (ci-log-info "There are  no build targets selected.")
+    ;; Complete  only those among the currently selected targets
+    (let ((completion-extra-properties (ci--target-completion-extra-properties))
+          (target (completing-read "Remove target: " ci-current-build-targets nil t)))
+      (setq ci-current-build-targets (delete target ci-current-build-targets))
+      (ci--forget-stale-runnable-targets) target)))
+
+;;;###autoload (autoload 'cmake-integration-clear-build-targets "cmake-integration")
+(defun ci-clear-build-targets ()
+  "Clear the selected build targets and the remembered run/debug targets."
+  (interactive)
+  (setq ci-current-build-targets nil
+        ci-current-run-target nil
+        ci-current-debug-target nil))
 
 
 ;;;###autoload (autoload 'cmake-integration-save-and-compile "cmake-integration")
@@ -341,12 +407,10 @@ that is not possible, ask for the target name without
 completions."
 
   (interactive)
-  ;; Ask the user for a target and set the
-  ;; cmake-integration-current-target variable with the chosen target
-  ;; name
-  (ci-select-current-target)
-
-  (ci--save-and-compile-no-completion ci-current-target))
+  (ci-select-build-targets)
+  (if ci-current-build-targets
+      (ci--save-and-compile-no-completion ci-current-build-targets)
+    (message "No build targets selected; nothing to build.")))
 
 
 ;;;###autoload (autoload 'cmake-integration-save-and-compile-last-target "cmake-integration")
@@ -357,12 +421,12 @@ See the documentation of `cmake-integration-get-build-command' for the
 EXTRA-ARGS parameter."
   (interactive)
   (ci--save-and-compile-no-completion
-   (or ci-current-target "all")
+   (or ci-current-build-targets '("all"))
    extra-args))
 
 
-(defun ci-get-build-command (target &optional extra-args)
-  "Get the command to compile target TARGET passing EXTRA-ARGS to cmake.
+(defun ci-get-build-command (targets &optional extra-args)
+  "Get the command to compile target TARGETS passing EXTRA-ARGS to cmake.
 
 Return a list (RUN-DIR COMMAND), where RUN-DIR is the directory from
 which the command must be executed, and COMMAND is the command line
@@ -370,26 +434,26 @@ string to run.
 
 EXTRA-ARGS is a list of strings, which will be joined with a space as
 separation and then passed to cmake command to build the target."
-  (pcase-let* ((`(,target-name ,config-name)
-                (split-string target ci--multi-config-separator))
-               (project-root (ci--get-project-root-folder))
-               (preset-arg-or-build-folder (if ci-build-preset
-                                               (format "--preset %s" (ci-get-last-build-preset-name))
-                                             (ci--get-build-folder-relative-to-project)))
-               (build-args extra-args))
-
-    ;; Add configuration argument if available
-    (when config-name (push (format "--config %s" config-name) build-args))
-
-    ;; Add the target
-    (push (format "--target %s" target-name) build-args)
-
-    ;; Add build folder or preset part
-    (push preset-arg-or-build-folder build-args)
-
-    ;; Return (run-dir command)
+  (pcase-let* ((target-list (ci--ensure-target-list targets))
+               (split (mapcar (lambda (name)
+                                (split-string name ci--multi-config-separator))
+                              target-list))
+               (names (mapcar #'car split))
+               (configs (delete-dups (delq nil (mapcar #'cadr split))))
+               (`(,project-root ,preset-or-folder ,build-args)
+                (list (ci--get-project-root-folder)
+                      (if ci-build-preset
+                          (format "--preset %s" (ci-get-last-build-preset-name))
+                        (ci--get-build-folder-relative-to-project))
+                      extra-args)))
+    (when (> (length configs) 1)
+      (user-error "Selected build targets use mixed configurations (%s)"
+                  (string-join configs ", ")))
+    (when configs
+      (push (format "--config %s" (car configs)) build-args))
+    (push (format "--target %s" (string-join names " ")) build-args)
+    (push preset-or-folder build-args)
     (list project-root (format "cmake --build %s" (string-join build-args " ")))))
-
 
 ;; See CMake file API documentation for what projectIndex is
 ;; https://cmake.org/cmake/help/latest/manual/cmake-file-api.7.html

--- a/cmake-integration-extra.el
+++ b/cmake-integration-extra.el
@@ -54,7 +54,7 @@ TARGET-NAME. Executes BODY in the context where `target-folder' is bound
 to the target directory."
   `(progn
      (ci--check-if-build-folder-exists-and-throws-if-not)
-     (let* ((target-name (or ,target-name ci-current-target))
+     (let* ((target-name (or ,target-name (ci--resolve-runnable-target 'ci-current-run-target)))
             (executable-relative-path (ci-get-target-executable-filename target-name))
             (target-full-path (ci-get-target-executable-full-path executable-relative-path))
             (target-folder (file-name-directory target-full-path)))

--- a/cmake-integration-launch-functions.el
+++ b/cmake-integration-launch-functions.el
@@ -94,7 +94,7 @@ the \"--cd\" option."
 
 
 (defun ci-dape-debug-launch-function (executable-path &optional args run-dir)
-  "Debug EXECUTABLE-PATH with dape, passign ARGS and using RUN-DIR as cwd.
+  "Debug EXECUTABLE-PATH with dape, passing ARGS and using RUN-DIR as cwd.
 
 Note: This is EXPERIMENTAL and has not been tested much. It may also
 break in the future in case dap changes, since there is no official
@@ -104,10 +104,16 @@ documentation on how to call it from Lisp."
         (args-vector (if args
                          (vconcat (split-string args " " t))
                        [])))
-    ;; Dape documentaton does not tell us how to call it from lisp. Hence, this
+    ;; Dape documentation does not tell us how to call it from lisp. Hence, this
     ;; could break in the future. The current approach was taken from the dape's
     ;; author information in this github issue:
     ;; https://github.com/svaante/dape/issues/193
+    ;;
+    ;; Paths are intentionally baked as concrete values here: every
+    ;; `ci-debug-last-target' invocation recomputes EXECUTABLE-PATH and
+    ;; RUN-DIR from the current debug target, so each session gets fresh
+    ;; values.  Programmatic `dape' calls do not push onto
+    ;; `dape-history', so there is no stale re-launch concern.
     (dape `( command "gdb"
              command-args ("--interpreter=dap")
              command-cwd ,default-directory

--- a/cmake-integration-launch.el
+++ b/cmake-integration-launch.el
@@ -32,6 +32,102 @@
 (require 'cmake-integration-launch-functions)
 (require 'cmake-integration-logging)
 
+(defun ci--executable-targets ()
+  "Return the names of all executable targets in the project.
+
+Reads them from the CMake file-api codemodel, ignoring which
+build targets are currently selected."
+
+  (when-let* ((json-filename (ci--get-codemodel-reply-json-filename)))
+    (mapcar #'car
+            (seq-filter (lambda(entry)
+                          (equal (alist-get 'type (cdr entry)) "EXECUTABLE"))
+                        (ci--get-annotated-targets-from-codemodel-json-file json-filename)))))
+
+(defun ci--current-executable-build-targets ()
+  "Return the selected build targets that are executables.
+
+Filters `ci-current-build-targets' down to executable targets,
+keeping their selection order."
+
+  (let ((executables (ci--executable-targets)))
+    (seq-filter (lambda (name) (member name executables)) ci-current-build-targets)))
+
+(defun ci--resolve-runnable-target (remembered-var &optional action)
+  "Return the target stored in REMEMBERED-VAR for running/debugging.
+
+If REMEMBERED-VAR (`ci-current-run-target' or
+`ci-current-debug-target') is non-nil it is honored blindly;
+launch-time checks remain the only validation.  Otherwise the
+first best candidate is auto-picked, stored in REMEMBERED-VAR and
+returned: executables among the selected build targets first,
+falling back to any project executable.  ACTION labels log
+messages and defaults to \"Run\"."
+
+  (or (symbol-value remembered-var)
+      (let* ((action (or action "Run"))
+             (choice (car (or (ci--current-executable-build-targets)
+                              (ci--executable-targets)))))
+        (unless choice
+          (error "%s: no executable targets found in the project" action))
+        (set remembered-var choice)
+        (ci-log-info "%s target auto-selected: %s" action choice)
+        choice)))
+
+
+(defun ci--select-runnable-target (remembered-var action)
+  "Prompt for an executable target and store it in REMEMBERED-VAR.
+
+Candidates come from all project executables, with the current
+value of REMEMBERED-VAR offered as default.  ACTION labels the
+prompt and log messages (\"Run\" or \"Debug\").  This is an
+explicit user request, so it always overwrites."
+
+  (let* ((candidates (or (ci--executable-targets)
+                         (user-error "%s: no executable targets found in the project"
+                                     action)))
+         (target (completing-read
+                  (format "%s target: " action)
+                  candidates
+                  nil
+                  t
+                  nil
+                  nil
+                  (symbol-value remembered-var))))
+    (set remembered-var target)
+    (ci-log-info "%s target selected: %s" action target)))
+
+;;;###autoload (autoload 'cmake-integration-select-run-target "cmake-integration")
+(defun ci-select-run-target ()
+  "Select the target to use when running, from the project executables.
+
+Overwrites `ci-current-run-target'; `ci-current-debug-target' is
+left untouched. Unless you have an explicit reason to use different
+run and debug targets, use `ci-select-run-and-debug-target' instead."
+  (interactive)
+  (ci--select-runnable-target 'ci-current-run-target "Run"))
+
+;;;###autoload (autoload 'cmake-integration-select-debug-target "cmake-integration")
+(defun ci-select-debug-target ()
+  "Select the target to use when debugging, from the project executables.
+
+Overwrites `ci-current-debug-target'; `ci-current-run-target' is
+left untouched. Unless you have an explicit reason to use different
+run and debug targets, use `ci-select-run-and-debug-target' instead."
+  (interactive)
+  (ci--select-runnable-target 'ci-current-debug-target "Debug"))
+
+;;;###autoload (autoload 'cmake-integration-select-run-and-debug-target "cmake-integration")
+(defun ci-select-run-and-debug-target ()
+  "Select one executable target to use for both running and debugging.
+
+Prompts once and stores the choice in both
+`ci-current-run-target' and `ci-current-debug-target'.  This is an
+explicit user request, so both are always overwritten."
+  (interactive)
+  (ci--select-runnable-target 'ci-current-run-target "Run")
+  (set 'ci-current-debug-target ci-current-run-target))
+
 
 (defun ci-get-target-executable-filename (&optional target)
   "Get the executable filename for the target TARGET.
@@ -41,14 +137,8 @@ something like just <target-name>, or bin/<target-name>.
 
 Throws an error if the target is not an executable.
 
-If TARGET-NAME is not provided use the last target (saved in a
-`cmake-integration-current-target')."
-
-  ;; If both `target' and `cmake-integration-current-target' are nil,
-  ;; throw an error asking the UE to select a target first by calling
-  ;; `cmake-integration-save-and-compile'
-  (unless (or target ci-current-target)
-    (error "Please select a target first by calling `cmake-integration-select-current-target`"))
+If TARGET is not provided, `ci-current-run-target' is used. If
+that is nil as well, an error is signaled."
 
   ;; The `target-info' variable inside the `let' has the data from the
   ;; codemodel json file for TARGET-NAME. This data is an alist and
@@ -56,7 +146,9 @@ If TARGET-NAME is not provided use the last target (saved in a
   ;; file with more data about the target. We read this json file and
   ;; save the data in the `target-data' variable. From there we can
   ;; get the executable name from its `artifacts' field.
-  (let* ((target (or target ci-current-target))
+  (let* ((target (or target ci-current-run-target))
+         (_ (unless target
+              (user-error "No run target selected. Select build targets and run targets accordingly!")))
          (target-name (car (split-string target ci--multi-config-separator)))
          (target-info (alist-get
                        target
@@ -82,10 +174,13 @@ If TARGET-NAME is not provided use the last target (saved in a
         ;; We assume the vector has just one element
         (alist-get 'path (elt target-artifacts 0))))))
 
-
 (defun ci--get-working-directory (&optional executable-filename)
-  "Get the working directory to run EXECUTABLE-FILENAME."
-  (let* ((executable-filename (or executable-filename ci-current-target)))
+  "Get the working directory to run EXECUTABLE-FILENAME.
+
+If EXECUTABLE-FILENAME is not provided, it is derived from
+`ci-current-run-target' via `ci-get-target-executable-filename',
+which signals an error when no target is selected."
+  (let* ((executable-filename (or executable-filename (ci-get-target-executable-filename))))
     (pcase ci-run-working-directory
       ('root (ci--get-project-root-folder))
       ('build (ci-get-build-folder))
@@ -111,9 +206,10 @@ If called interactively, the result is copied to the `kill-ring`."
     full-path))
 
 
-(defun ci--get-program-launch-buffer-name ()
-  "Get the compilation buffer name for NAME-OF-MODE current target name."
-  (format "*Running - %s*" cmake-integration-current-target))
+(defun ci--get-program-launch-buffer-name (target-name)
+  "Get the compilation buffer name for TARGET-NAME."
+
+  (format "*Running - %s*" target-name))
 
 
 (defun ci--get-run-command (executable-filename)
@@ -133,14 +229,16 @@ string to run."
 ;;;###autoload (autoload 'cmake-integration-run-last-target "cmake-integration")
 (defun ci-run-last-target ()
   "Run the last compiled target."
+
   (interactive)
   (ci--check-if-build-folder-exists-and-throws-if-not)
 
-  (let ((bufer-name
-         (when ci-use-separated-compilation-buffer-for-each-target
-           (ci--get-program-launch-buffer-name))))
+  (let* ((target (ci--resolve-runnable-target 'ci-current-run-target))
+         (bufer-name
+          (when ci-use-separated-compilation-buffer-for-each-target
+            (ci--get-program-launch-buffer-name target))))
     (pcase-let* ((`(,run-dir ,cmd)
-                  (ci--get-run-command (ci-get-target-executable-filename))))
+                  (ci--get-run-command (ci-get-target-executable-filename target))))
       (let ((default-directory run-dir))
         (cond
          ((eq ci-program-launcher-function 'compilation)
@@ -159,11 +257,12 @@ string to run."
 
 ;;;###autoload (autoload 'cmake-integration-debug-last-target "cmake-integration")
 (defun ci-debug-last-target ()
-  "Run the last compiled target."
+  "Run debugger with the current debug target."
+
   (interactive)
   (ci--check-if-build-folder-exists-and-throws-if-not)
-
-  (let* ((executable-filename (ci-get-target-executable-filename))
+  (let* ((target (ci--resolve-runnable-target 'ci-current-debug-target "Debug"))
+         (executable-filename (ci-get-target-executable-filename target))
          (run-dir (ci--get-working-directory executable-filename))
          (executable-path
           (file-relative-name

--- a/cmake-integration-persistence.el
+++ b/cmake-integration-persistence.el
@@ -46,7 +46,9 @@
 
     ;; Target
     ci--target-extra-data-cache
-    ci-current-target
+    ci-current-build-targets
+    ci-current-run-target
+    ci-current-debug-target
     ci-run-arguments
 
     ;; Presets
@@ -64,7 +66,13 @@
 
 
 (defconst ci-functions-to-save-state
-  '(ci-select-current-target
+  '(ci-select-build-targets
+    ci-add-build-target
+    ci-remove-build-target
+    ci-clear-build-targets
+    ci-select-run-target
+    ci-select-debug-target
+    ci-select-run-and-debug-target
     ci-select-configure-preset
     ci-add-cmake-cache-variables
     ci-remove-cmake-cache-variable
@@ -79,7 +87,7 @@
   "Functions which automatically save cmake-intregration state.
 
 State is only saved if `ci-automatic-persistence-mode' is enabled."
-)
+  )
 
 
 (defconst ci-functions-to-restore-state
@@ -129,7 +137,7 @@ Return nil if not in a project."
 
 Return nil if not in a project."
   (if-let* ((root-folder (ci--get-project-root-folder)))
-    (file-name-concat root-folder "cmake-integration/")))
+      (file-name-concat root-folder "cmake-integration/")))
 
 
 (defun ci--persist-directory (&optional ensure)
@@ -150,10 +158,10 @@ Return nil if not in a project."
                (user-error
                 "Invalid value for 'cmake-integration-persist-location': %S"
                 ci-persist-location)))))
-    (let ((expanded-dir (expand-file-name dir)))
-      (when ensure
-        (make-directory expanded-dir t))
-      expanded-dir)))
+      (let ((expanded-dir (expand-file-name dir)))
+        (when ensure
+          (make-directory expanded-dir t))
+        expanded-dir)))
 
 
 (defun ci--get-persist-file (&optional ensure-directory)
@@ -173,7 +181,7 @@ If ENSURE-DIRECTORY is non-nil, create the directory when necessary."
 (defun ci--state-file-exists-p ()
   "Returns non-nil if the cmake-integration state file exists."
   (if-let* ((state-file (ci--get-persist-file)))
-    (file-exists-p state-file)))
+      (file-exists-p state-file)))
 
 
 ;;;###autoload (autoload 'cmake-integration-should-restore-state-p "cmake-integration")
@@ -236,9 +244,9 @@ function can be used as an advice."
 
 (defun ci--deserialize-state (state-file-name)
   "Deserialize the state from STATE-FILE-NAME."
-    (with-temp-buffer
-        (insert-file-contents state-file-name)
-        (read (current-buffer))))
+  (with-temp-buffer
+    (insert-file-contents state-file-name)
+    (read (current-buffer))))
 
 
 (defun ci--restore-variables-from-state (state)
@@ -252,7 +260,14 @@ This is the inverse of the `ci--build-current-state' function."
     (let ((var (car entry))
           (value (cdr entry)))
       (when (memq var ci--state-variables)
-        (set var value)))))
+        (set var value))))
+
+  ;; Migration: states saved before multi-target support stored the
+  ;; single selection in `ci-current-target'
+  (unless (assq 'ci-current-build-targets state)
+    (let ((old-value (alist-get 'ci-current-target state)))
+      (when old-value
+        (setq ci-current-build-targets (list old-value))))))
 
 
 ;;;###autoload (autoload 'cmake-integration-restore-state "cmake-integration")
@@ -260,26 +275,26 @@ This is the inverse of the `ci--build-current-state' function."
   "Restore the state of cmake-integration from persistent storage."
   (interactive)
   (if-let* ((state-file (ci--get-persist-file)))
-    (cond
-     ((not (ci-is-cmake-project-p))
-      (ci-log-info "Current project in '%s' is not a CMake project"
-               (ci--get-project-root-folder)))
-     ((not (file-readable-p state-file))
-      (when (called-interactively-p 'interactive)
-        (ci-log-info "No cmake-integration state file found at %s" state-file)))
-     (t
-      (condition-case err
-          (let ((state (ci--deserialize-state state-file)))
-            (ci--restore-variables-from-state state))
+      (cond
+       ((not (ci-is-cmake-project-p))
+        (ci-log-info "Current project in '%s' is not a CMake project"
+                     (ci--get-project-root-folder)))
+       ((not (file-readable-p state-file))
+        (when (called-interactively-p 'interactive)
+          (ci-log-info "No cmake-integration state file found at %s" state-file)))
+       (t
+        (condition-case err
+            (let ((state (ci--deserialize-state state-file)))
+              (ci--restore-variables-from-state state))
 
-        (error
-         (ci-log-info
-          "An error occurred while restoring cmake-integration state from %s: %s"
-          state-file (error-message-string err))))
-      (when (called-interactively-p 'interactive)
-        (ci-log-info "State restored from %s" state-file))
+          (error
+           (ci-log-info
+            "An error occurred while restoring cmake-integration state from %s: %s"
+            state-file (error-message-string err))))
+        (when (called-interactively-p 'interactive)
+          (ci-log-info "State restored from %s" state-file))
 
-      (setq ci-last-save-or-restore-state state-file)))
+        (setq ci-last-save-or-restore-state state-file)))
 
     (when (called-interactively-p 'interactive)
       (ci-log-info "No state file location resolved."))))

--- a/cmake-integration-transient.el
+++ b/cmake-integration-transient.el
@@ -133,13 +133,24 @@ will be obtained from PRESET and this returns the string
   (format "Package preset (%s)"
           (ci--describe-preset-command-line ci-package-preset)))
 
+(defun ci--describe-build-targets ()
+  "Describe the command line argument to set the build targets."
+  (let* ((target-names (string-join (or ci-current-build-targets '()) " "))
+         (command-line (format "--target=%s" target-names)))
+    (format "Set Targets (%s)"
+            (ci--get-command-line-arg-with-face command-line target-names))))
 
-(defun ci--describe-build-target ()
-  "Describe the command line argument to set the build target."
-  (let* ((target-name (if ci-current-target ci-current-target ""))
-         (command-line (format "--target=%s" target-name)))
-    (format "Set Target (%s)" (ci--get-command-line-arg-with-face command-line ci-current-target))))
+(defun ci--describe-run-target ()
+  "Describe the current run target."
+  (let ((target-name (or ci-current-run-target "")))
+    (format "Run (%s)"
+            (ci--get-command-line-arg-with-face target-name target-name))))
 
+(defun ci--describe-debug-target ()
+  "Describe the current debug target."
+  (let ((target-name (or ci-current-debug-target "")))
+    (format "Debug (%s)"
+            (ci--get-command-line-arg-with-face target-name target-name))))
 
 (defun ci--describe-conan-profile ()
   "Describe the current conan profile."
@@ -235,16 +246,35 @@ will be obtained from PRESET and this returns the string
 
 (transient-define-suffix ci--set-build-target-suffix ()
   :transient 'transient--do-call
-  :description 'ci--describe-build-target
+  :description 'ci--describe-build-targets
   (interactive)
-  (ci-select-current-target))
+  (ci-select-build-targets))
 
 
 (transient-define-suffix ci--clear-build-target-suffix ()
   :transient 'transient--do-call
-  :description "Clear build target"
+  :description "Clear build targets"
   (interactive)
-  (setq ci-current-target nil))
+  (ci-clear-build-targets))
+
+
+(transient-define-suffix ci--set-run-target-suffix ()
+  :transient 'transient--do-call
+  :description "Set run and debug target"
+  (interactive)
+  (ci-select-run-and-debug-target))
+
+(transient-define-suffix ci--run-target-suffix ()
+  :transient 'transient--do-call
+  :description 'ci--describe-run-target
+  (interactive)
+  (ci-run-last-target))
+
+(transient-define-suffix ci--debug-target-suffix ()
+  :transient 'transient--do-call
+  :description 'ci--describe-debug-target
+  (interactive)
+  (ci-debug-last-target))
 
 
 (transient-define-suffix ci--set-conan-profile-suffix ()
@@ -270,9 +300,9 @@ will be obtained from PRESET and this returns the string
   :transient 'transient--do-call
   ;; :description 'ci--describe-install-prefix
   :description (lambda () (format "%s runtime arguments"
-                             (if ci-run-arguments
-                                 "Edit"
-                               "Set")))
+                                  (if ci-run-arguments
+                                      "Edit"
+                                    "Set")))
   (interactive)
   (let ((run-arguments (read-string "Arguments to pass to the executable: ")))
     ;; If the user didn't provide any arguments, we set it to nil
@@ -350,25 +380,25 @@ will be obtained from PRESET and this returns the string
 
 
 (transient-define-prefix
- ci--cache-variables-transient () "Show CMake cache variables."
- ["Cache Variables"
-  (:info #'ci--describe-cache-variables)
-  ("v" "View cache variables" ci-display-cmake-cache-variables :transient t)
-  ("a" "Add a cache variable" ci-add-cmake-cache-variables :transient t)
-  ("r" "Remove a cache variable" ci-remove-cmake-cache-variable :transient t)
-  ("R"
-   "Remove all cache variables"
-   ci-remove-all-cmake-cache-variables
-   :transient t)
-  ("q" "Quit"
-   (lambda ()
-     (interactive)
-     ;; If the buffer displaying the cache variables is open, close it before
-     ;; quitting the transient
-     (ci--maybe-quit-cache-variables-window)
-     (transient-quit-one))) ;;
-  ]
- )
+  ci--cache-variables-transient () "Show CMake cache variables."
+  ["Cache Variables"
+   (:info #'ci--describe-cache-variables)
+   ("v" "View cache variables" ci-display-cmake-cache-variables :transient t)
+   ("a" "Add a cache variable" ci-add-cmake-cache-variables :transient t)
+   ("r" "Remove a cache variable" ci-remove-cmake-cache-variable :transient t)
+   ("R"
+    "Remove all cache variables"
+    ci-remove-all-cmake-cache-variables
+    :transient t)
+   ("q" "Quit"
+    (lambda ()
+      (interactive)
+      ;; If the buffer displaying the cache variables is open, close it before
+      ;; quitting the transient
+      (ci--maybe-quit-cache-variables-window)
+      (transient-quit-one))) ;;
+   ]
+  )
 
 
 (transient-define-prefix ci--configure-transient ()
@@ -422,7 +452,7 @@ will be obtained from PRESET and this returns the string
    ("e" ci--set-ctest-label-exclude-regexp-suffix)
    ("p" "Print test labels" (lambda () (interactive)
                               (ci-log-info "Available test labels:\n%s"
-                                       (s-join ", " (ci--get-all-ctest-labels))))
+                                           (s-join ", " (ci--get-all-ctest-labels))))
     :transient t)
    ("q" "Back" transient-quit-one)
    ]
@@ -480,19 +510,14 @@ will be obtained from PRESET and this returns the string
    ]
   )
 
-
 (transient-define-prefix ci--launch-transient ()
   "Perform actions related to running or debugging an executable target."
   ["Run and Debug"
-   (:info #'ci--describe-runtime-args)
    ("a" ci--set-runtime-arguments-suffix)
-   ("t" ci--set-build-target-suffix)
-   ("r" "Run" ci-run-last-target)
-   ("d" "Debug" ci-debug-last-target)
-   ("q" "Quit" transient-quit-one)
-   ]
-  )
-
+   ("t" ci--set-run-target-suffix)
+   ("r" ci--run-target-suffix)
+   ("d" ci--debug-target-suffix)
+   ("q" "Quit" transient-quit-one)])
 
 (transient-define-prefix ci--workflow-transient ()
   "Perform actions related to running a workflow."

--- a/cmake-integration-variables.el
+++ b/cmake-integration-variables.el
@@ -223,8 +223,9 @@ will be replaced by the project root." :type 'directory :group 'cmake-integratio
   :group 'cmake-integration-persistence)
 
 
-(defvar ci-current-target nil "Name of the target that will be compiled and run.")
-
+(defvar ci-current-build-targets nil "List of the targets names that will be built.")
+(defvar ci-current-run-target nil "Name of the target that will be run.")
+(defvar ci-current-debug-target nil "Name of the target that will be debug-run.")
 
 ;; Note: Avoid modifying this variable directly. Use one of the functions below
 ;; instead

--- a/tests/cmake-integration-tests.el
+++ b/tests/cmake-integration-tests.el
@@ -29,6 +29,7 @@
 
 ;;; Code:
 (require 'ert)
+(require 'cl-lib)
 (require 'cmake-integration)
 
 
@@ -377,30 +378,30 @@ test code from inside a 'test project'."
 (ert-deftest test-ci--get-working-directory ()
   (test-fixture-setup ;;
    "./test-project-with-presets"
-   (let ((ci-current-target "bin/main")
+   (let ((executable-filename "bin/main")
          (ci-configure-preset
           '((name . "default") (binaryDir . "${sourceDir}/build-with-ninja/"))))
      (let ((ci-run-working-directory 'root))
        (should
         (equal
-         (ci--get-working-directory ci-current-target)
+         (ci--get-working-directory executable-filename)
          (ci--get-project-root-folder))))
 
      (let ((ci-run-working-directory 'build))
        (should
         (equal
-         (ci--get-working-directory ci-current-target) (ci-get-build-folder))))
+         (ci--get-working-directory executable-filename) (ci-get-build-folder))))
 
      (let ((ci-run-working-directory 'bin))
        (should
         (equal
-         (ci--get-working-directory ci-current-target)
+         (ci--get-working-directory executable-filename)
          (file-name-concat (ci-get-build-folder) "bin/"))))
 
      (let ((ci-run-working-directory "some/subfolder/"))
        (should
         (equal
-         (ci--get-working-directory ci-current-target)
+         (ci--get-working-directory executable-filename)
          (file-name-concat (ci--get-project-root-folder)
                            "some/subfolder/")))))))
 
@@ -408,17 +409,17 @@ test code from inside a 'test project'."
 (ert-deftest test-ci-get-target-executable-full-path ()
   (test-fixture-setup ;;
    "./test-project-with-presets"
-   (let ((ci-current-target "bin/main"))
+   (let ((executable-filename "bin/main"))
      (should
       (equal
-       (ci-get-target-executable-full-path ci-current-target)
-       (file-name-concat (ci-get-build-folder) ci-current-target))))
+       (ci-get-target-executable-full-path executable-filename)
+       (file-name-concat (ci-get-build-folder) executable-filename))))
 
-   (let ((ci-current-target "main"))
+   (let ((executable-filename "main"))
      (should
       (equal
-       (ci-get-target-executable-full-path ci-current-target)
-       (file-name-concat (ci-get-build-folder) ci-current-target))))))
+       (ci-get-target-executable-full-path executable-filename)
+       (file-name-concat (ci-get-build-folder) executable-filename))))))
 
 
 (ert-deftest test-ci--get-run-command--root-folder ()
@@ -1187,6 +1188,83 @@ test code from inside a 'test project'."
     (should-not (ci--target-is-not-library-p object-library-target-info))
     (should (ci--target-is-not-library-p utility-target-info))
     (should (ci--target-is-not-library-p unknown-target-info))))
+
+
+;; xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+;; xxxxxxx Multi-target and run/debug target selection xxxxxxxxxxxxxxx
+;; xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+(ert-deftest test-ci--executable-targets ()
+  ;; Only targets of type EXECUTABLE are returned; phony targets
+  ;; ("all", "clean") and libraries are filtered out.
+  (test-fixture-setup
+   "./test-project-with-codemodel-reply"
+   (let ((executables (ci--executable-targets)))
+     (should (member "main" executables))
+     (should-not (member "somelib" executables))
+     (should-not (member "all" executables))
+     (should-not (member "clean" executables)))))
+
+
+(ert-deftest test-ci--current-executable-build-targets ()
+  ;; Intersects the selected build targets with the project
+  ;; executables.  Non-executable selections yield an empty list.
+  (test-fixture-setup
+   "./test-project-with-codemodel-reply"
+   (let ((ci-current-build-targets '("somelib" "main" "clean")))
+     (should (equal (ci--current-executable-build-targets) '("main"))))
+   (let ((ci-current-build-targets '("somelib")))
+     (should (null (ci--current-executable-build-targets))))
+   (let ((ci-current-build-targets nil))
+     (should (null (ci--current-executable-build-targets))))))
+
+
+(ert-deftest test-ci--resolve-runnable-target ()
+  (test-fixture-setup
+   "./test-project-with-codemodel-reply"
+   ;; Non-nil memories are honored blindly, even if not a real target
+   (let ((ci-current-run-target "whatever"))
+     (should (equal (ci--resolve-runnable-target 'ci-current-run-target)
+                    "whatever")))
+   ;; Empty memories are auto-seeded from the project executables...
+   (let ((ci-current-run-target nil))
+     (should (equal (ci--resolve-runnable-target 'ci-current-run-target)
+                    "main"))
+     ;; ...and the seed is stored back into the memory variable
+     (should (equal ci-current-run-target "main")))))
+
+
+(ert-deftest test-ci-select-run-and-debug-target-writes-both ()
+  ;; The default selector prompts once and writes both memories.
+  (test-fixture-setup
+   "./test-project-with-codemodel-reply"
+   (let ((ci-current-run-target nil)
+         (ci-current-debug-target nil))
+     (cl-letf (((symbol-function 'completing-read)
+                (lambda (&rest _) "main")))
+       (ci-select-run-and-debug-target))
+     (should (equal ci-current-run-target "main"))
+     (should (equal ci-current-debug-target "main"))
+     ;; The individual selectors overwrite only their own memory
+     (cl-letf (((symbol-function 'completing-read)
+                (lambda (&rest _) "other")))
+       (ci-select-debug-target))
+     (should (equal ci-current-run-target "main"))
+     (should (equal ci-current-debug-target "other")))))
+
+
+(ert-deftest test-ci--restore-variables-from-state-migration ()
+  ;; States saved before multi-target support stored the single
+  ;; selection in `ci-current-target'; they migrate into the build
+  ;; target list.
+  (let ((ci-current-build-targets nil))
+    (ci--restore-variables-from-state '((ci-current-target . "old-main")))
+    (should (equal ci-current-build-targets '("old-main"))))
+  ;; New-style states are restored as-is, without migration
+  (let ((ci-current-build-targets nil))
+    (ci--restore-variables-from-state
+     '((ci-current-build-targets . ("kept" "added"))))
+    (should (equal ci-current-build-targets '("kept" "added")))))
 
 
 ;; get-target-executable-filename


### PR DESCRIPTION
This is a first working version of multi-target build support together with explicit,
independent selection of the run and debug executables. It ended up larger than a
typical patch, so early feedback on the general direction is very welcome before more
polish lands.

**What it does**

- `select-build-targets` accepts several targets at once (comma-separated completion),
  with add/remove/clear helpers. Compiling builds all of them.
- Running and debugging use their own remembered executables instead of the last built
  target. A joint selector sets both at once; individual commands allow diverging them.
- Both selections persist across sessions; old state files keep working through a small
  migration step.
- The existing Run and Debug transient menu was reworked around these selectors, with
  descriptions showing current selections.

**Prior art**: this exact combination is a long-standing gap in VS Code's CMake Tools.
Multiple build targets were requested back in 2020 ([#1360 — Active Target does not allow special or multiple targets](https://github.com/microsoft/vscode-cmake-tools/issues/1360)) and again in 2023 ([#3441 — Unable to build multiple targets](https://github.com/microsoft/vscode-cmake-tools/issues/3441)), both still open. The extension does keep separate build and launch target selections, and a joint setter was added after user demand ([#4466 — Add a command to set the build AND launch target](https://github.com/microsoft/vscode-cmake-tools/issues/4466), implemented in [PR #4732](https://github.com/microsoft/vscode-cmake-tools/pull/4732)).

Related discussions on coupling semantics between build and launch/debug targets: [#2625 — Automatically select the current launch target as build target](https://github.com/microsoft/vscode-cmake-tools/issues/2625), [#4445 — Debug command also builds the build target](https://github.com/microsoft/vscode-cmake-tools/issues/4445).

This PR brings the same/similar model to Emacs, adapted to the package's transient workflow:
several build targets compiled together, and run/debug executables selected explicitly,
jointly or independently, persisting across sessions.

**Status**
This PR is intentionally kept as a draft. The feature works and I have been using it
daily on my own projects for a while now, but some design decisions — especially how
the transient menus present and organize these selectors — deserve input from people
who know the package's UX goals better than I do. Confirmation of the general
direction would already be very helpful, and collaboration would be even better if
anyone is interested in this area. I plan to keep working on it whenever time allows.